### PR TITLE
fix shootout/revcomp.p6.pl

### DIFF
--- a/shootout/revcomp.p6.pl
+++ b/shootout/revcomp.p6.pl
@@ -4,7 +4,7 @@
 #
 # USAGE: perl6 revcomp.p6.pl < revcomp.input
 
-my($desc,$seq) = ('','');
+my ($desc,$seq) = ('','');
 while $*IN.get -> $line {
 	if $line.match(/^ \>/) {
 		print_revcomp();


### PR DESCRIPTION
missing space between `my` and `(`
