### PR TITLE
make provision for adding cookbook tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,23 @@
 .PHONY: html test help
 
+help:
+	@echo "Usage: make [html|test|test-cookbook]"
+	@echo ""
+	@echo "Options:"
+	@echo "   html:             generate the HTML documentation"
+	@echo "   test:             run the test suite"
+	@echo "   test-sub:         run subdir tests"
+
 html:
 	perl6 htmlify.pl
 
 test:
 	prove --exec perl6 -r t
 
-help:
-	@echo "Usage: make [html|test]"
-	@echo ""
-	@echo "Options:"
-	@echo "   html:             generate the HTML documentation"
-	@echo "   test:             run the test suite"
+test-sub:
+	@if test -d "categories/cookbook/t" ; then \
+	  prove --exec perl6 -r categories/cookbook/t ; \
+	else \
+	  echo "No test subdir found." ; \
+	fi
+


### PR DESCRIPTION
Suggesting a couple of things:

1. make the help target the default
2. make provision for possibly independent subdirectory tests (I plan to start with the cookbook directory)
