### PR TITLE
Fixed skipping the last word

### DIFF
--- a/categories/tutorial/01-word-wrap.pl
+++ b/categories/tutorial/01-word-wrap.pl
@@ -35,8 +35,8 @@ sub lines (@in) {
             $length += $l.chars;
         }
         else {
-            say '';
-            $length = 0;
+            print "\n$l ";
+            $length = $l.chars;
         }
     }
     say '';


### PR DESCRIPTION
This would originally skip the last word in the line without printing it to the next line. In other words, large lines of text would loose a word when it moved to the next line.