### PR TITLE
correct tests to be compatible with rakudo 2016.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: perl6
 
 perl6:
-    - 2016.01
+    - latest
 
 install:
     - rakudobrew build-panda 2016.01

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ EXAMPLES_DEPS = \
 		Text::VimColour \
 		HTTP::Easy \
 		Term::ANSIColor \
-		Web \
+		Web::Request \
 		Term::termios
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ EXAMPLES_DEPS = \
 		Text::VimColour \
 		HTTP::Easy \
 		Term::ANSIColor \
+		Web \
 		Term::termios
-
-#		Web::Request \
 
 help:
 	@echo "Usage: make <option>"

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ EXAMPLES_DEPS = \
 		File::Temp \
 		Text::VimColour \
 		HTTP::Easy \
-		Web::Request \
 		Term::ANSIColor \
 		Term::termios
+
+#		Web::Request \
 
 help:
 	@echo "Usage: make <option>"

--- a/categories/99-problems/P39-rhebus.pl
+++ b/categories/99-problems/P39-rhebus.pl
@@ -24,5 +24,7 @@ say ~ grep { .is-prime }, 10..20;
 
 # or we can pass a list...
 say ~ grep { .is-prime }, 3,5,17,257,65537;
+# or another range
+say ~ grep { .is-prime }, 1..100;
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/categories/99-problems/P40-rhebus.pl
+++ b/categories/99-problems/P40-rhebus.pl
@@ -35,6 +35,6 @@ sub goldbach (Even $n where * > 2 ) {
     return; # fail
 }
 
-say goldbach $_ for 28, 36, 52, 110, 62710560;
+say ~ goldbach $_ for 28, 36, 52, 110;
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/categories/99-problems/P40-rhebus.pl
+++ b/categories/99-problems/P40-rhebus.pl
@@ -35,6 +35,6 @@ sub goldbach (Even $n where * > 2 ) {
     return; # fail
 }
 
-say ~ goldbach $_ for 28, 36, 52, 110;
+say ~ goldbach $_ for 28, 36, 52, 110, 62710560;
 
 # vim: expandtab shiftwidth=4 ft=perl6

--- a/categories/euler/prob047-gerdr.pl
+++ b/categories/euler/prob047-gerdr.pl
@@ -39,7 +39,7 @@ After which, the example can be run as expected:
 
 use NativeCall;
 
-sub factors(int $n) returns int is native($*SPEC.catdir($*PROGRAM-NAME.IO.dirname, 'prob047-gerdr')) { * }
+sub factors(int32 $n) returns int32 is native($*SPEC.catdir($*PROGRAM-NAME.IO.dirname, 'prob047-gerdr')) { * }
 
 sub MAIN(Int $N = 4) {
     my int $n = 2;

--- a/t/000-check-dependencies.t
+++ b/t/000-check-dependencies.t
@@ -13,8 +13,8 @@ my @dependencies = qw{
     Term::ANSIColor
     Term::termios
     URI
+    Web
 };
-#    Web::Request
 
 plan @dependencies.elems;
 

--- a/t/000-check-dependencies.t
+++ b/t/000-check-dependencies.t
@@ -13,8 +13,8 @@ my @dependencies = qw{
     Term::ANSIColor
     Term::termios
     URI
-    Web::Request
 };
+#    Web::Request
 
 plan @dependencies.elems;
 

--- a/t/000-check-dependencies.t
+++ b/t/000-check-dependencies.t
@@ -13,7 +13,7 @@ my @dependencies = qw{
     Term::ANSIColor
     Term::termios
     URI
-    Web
+    Web::Request
 };
 
 plan @dependencies.elems;

--- a/t/categories/99-problems.t
+++ b/t/categories/99-problems.t
@@ -419,13 +419,14 @@ sub expected-output {
     END
 
     %expected-output{"P36-ovid.pl"} = q:to/END/;
-    Prime factors of 17 are: ("17" => 1,)
-    Prime factors of 53 are: ("53" => 1,)
-    Prime factors of 90 are: ("2" => 1, "3" => 2, "5" => 1)
-    Prime factors of 94 are: ("2" => 1, "47" => 1)
-    Prime factors of 200 are: ("2" => 3, "5" => 2)
-    Prime factors of 289 are: ("17" => 2,)
-    Prime factors of 62710561 are: ("7919" => 2,)
+    Prime factors of 2 are: {"2" => 1}
+    Prime factors of 17 are: {"17" => 1}
+    Prime factors of 53 are: {"53" => 1}
+    Prime factors of 90 are: {"2" => 1, "3" => 2, "5" => 1}
+    Prime factors of 94 are: {"2" => 1, "47" => 1}
+    Prime factors of 200 are: {"2" => 3, "5" => 2}
+    Prime factors of 289 are: {"17" => 2}
+    Prime factors of 62710561 are: {"7919" => 2}
     END
 
     %expected-output{"P36-rhebus.pl"} = q:to/END/;
@@ -481,7 +482,6 @@ sub expected-output {
     %expected-output{"P39-rhebus.pl"} = q:to/END/;
     11 13 17 19
     3 5 17 257 65537
-    1 2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97
     END
 
     %expected-output{"P40-rhebus.pl"} = q:to/END/;

--- a/t/categories/99-problems.t
+++ b/t/categories/99-problems.t
@@ -482,6 +482,7 @@ sub expected-output {
     %expected-output{"P39-rhebus.pl"} = q:to/END/;
     11 13 17 19
     3 5 17 257 65537
+    2 3 5 7 11 13 17 19 23 29 31 37 41 43 47 53 59 61 67 71 73 79 83 89 97
     END
 
     %expected-output{"P40-rhebus.pl"} = q:to/END/;
@@ -489,6 +490,7 @@ sub expected-output {
     5 31
     5 47
     3 107
+    7 62710553
     END
 
     %expected-output{"P41-rhebus.pl"} = q:to/END/;

--- a/t/categories/cookbook/14database-access.t
+++ b/t/categories/cookbook/14database-access.t
@@ -9,10 +9,12 @@ subtest {
 
     my $example-name = "14-09-dbi-sql.pl";
     my $expected-output = q:to/EOD/;
-    [title => Larry Wall - Keynote, APW2014 2014-10-10 , uri => https://www.youtube.com/watch?v=enlqVqit62Y title => Carl Mäsak - Regexes in Perl 6 - Zero to Perl 6 Training, uri => https://www.youtube.com/watch?v=oo-gA9Z9SaA]
+    [{title => Larry Wall - Keynote, APW2014 2014-10-10 , uri => https://www.youtube.com/watch?v=enlqVqit62Y} {title => Carl Mäsak - Regexes in Perl 6 - Zero to Perl 6 Training, uri => https://www.youtube.com/watch?v=oo-gA9Z9SaA}]
     EOD
 
     my $output = run-example($example-name);
+    say "output:";
+    say $output;
     is($output, $expected-output, $example-name);
     unlink "video.db"; # the script creates this file
 }, "14-09-dbi-sql.pl";


### PR DESCRIPTION
All tests passed on Deb 8, 64-bit, rakudo 2016.04.

.travis.yaml changed to use latest rakudo.