### PR TITLE
Change URL to a real http address

### DIFF
--- a/categories/cookbook/20web-automation/20-01-fetching-uri.pl
+++ b/categories/cookbook/20web-automation/20-01-fetching-uri.pl
@@ -12,7 +12,7 @@ You want to fetch a uri
 
 use LWP::Simple;
 
-my $html = LWP::Simple.get('http://perl6.org/');
+my $html = LWP::Simple.get('http://examples.perl6.org/');
 
 say $html;
 


### PR DESCRIPTION
http://perl6.org is getting redirected to https://perl6.org.