### PR TITLE
Added method get_animal() to complete 'function interpolate' example.

### DIFF
--- a/categories/cookbook/01strings/01-00introduction.pl
+++ b/categories/cookbook/01strings/01-00introduction.pl
@@ -398,6 +398,7 @@ qs//.
     say qh/We have %animal.elems() key in %animal{}/;
 
     # interpolate functions only: both & and () are required
+    sub get_animal ($tag) { return %animal{$tag}; }
     say q:f/The quick brown &get_animal('quick') jumps.../;
     say qf/The quick brown &get_animal('quick') jumps.../;
 


### PR DESCRIPTION
Hi Team,

Please review the PR.

This adds the missing method get_animal() to make the example for 'function interpolate" works out of the box.
Apology if you find this unnecessary noise.

Many Thanks.
Best Regards,
Mohammad S Anwar