### PR TITLE
malware analysis example

### DIFF
--- a/categories/other/malware_analysis.raku
+++ b/categories/other/malware_analysis.raku
@@ -1,0 +1,12 @@
+# configuring the genes and the virus (some virus share genes)
+
+my token gene {'this is a malware gene'}
+my rule virusx {<gene>.*}
+
+# reading the sample line by line from a binary file
+
+for '/script/mysample'.IO.lines -> $line {
+        # If the line contains the gene, print it
+    if $line ~~ &virusx {say "Genes from virus X were found: "; say $line; }
+
+}


### PR DESCRIPTION
This file, which is also explained in [here](https://dev.to/terceranexus6/raku-malware-analysis-jon) aims to mimic YARA malware detection standard using grammars. The whole idea is to use RAKU grammars for studying malware genes.